### PR TITLE
update: runtime image to scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
 # ---------- Stage 1: Build ----------
-    FROM golang:1.24-alpine AS build
+FROM golang:1.24 AS build
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o okport -ldflags="-s -w" main.go
 
-    WORKDIR /app
-    COPY . .
-    RUN go build -o okport main.go
-    
-    # ---------- Stage 2: Minimal runtime ----------
-    FROM alpine:latest
-    
-    WORKDIR /root/
-    
-    # Copy binary only (no source code)
-    COPY --from=build /app/okport .
-    
-    # Expose no ports explicitly (up to user via -p)
-    ENTRYPOINT ["./okport"]
+# ---------- Stage 2: Minimal runtime ----------
+FROM scratch
+
+# Copy binary only
+COPY --from=build /app/okport /okport
+
+ENTRYPOINT ["/okport"]


### PR DESCRIPTION
Updated the runtime image to scratch to keep the final image minimal and free from unnecessary dependencies.